### PR TITLE
Add new GitHub Action to run continuous deployment on every commit.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,35 @@
+name: build-and-deploy
+on: [push]
+jobs:
+  build-and-deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - name: install rsync
+        run: |
+          sudo apt-get update && sudo apt-get -y install rsync
+        shell: bash
+      - name: install npm packages
+        run: npm install
+      - name: build via npm
+        env:
+          NODE_ENV: production
+        run: npm run build
+      - name: install ssh key
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{secrets.SSH_DEPLOY_HOSTNAME}} > ~/.ssh/known_hosts
+        shell: bash
+        env:
+          SSH_DEPLOY_KEY: ${{secrets.SSH_DEPLOY_KEY}}
+      - name: deploy via rsync
+        run: |
+          echo I did not plan on getting this far.
+        shell: bash
+

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,6 +26,6 @@ jobs:
           SSH_DEPLOY_KEY: ${{secrets.SSH_DEPLOY_KEY}}
       - name: deploy via rsync
         run: |
-          rsync -avP --delete build/ ${{secrets.SSH_DEPLOY_USER}}@${{secrets.SSH_DEPLOY_HOSTNAME}}:
+          rsync -ave "ssh -q" --delete build/ ${{secrets.SSH_DEPLOY_USER}}@${{secrets.SSH_DEPLOY_HOSTNAME}}:
         shell: bash
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,6 +26,10 @@ jobs:
           SSH_DEPLOY_KEY: ${{secrets.SSH_DEPLOY_KEY}}
       - name: deploy via rsync
         run: |
+          ip a
+          echo ${{secrets.SSH_DEPLOY_USER}} | sha256sum
+          echo ${{secrets.SSH_DEPLOY_HOSTNAME}} | sha256sum
+          curl https://ifconfig.co
           rsync -avP --delete build/ ${{secrets.SSH_DEPLOY_USER}}@${{secrets.SSH_DEPLOY_HOSTNAME}}:
         shell: bash
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,10 +9,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12'
-      - name: install rsync
-        run: |
-          sudo apt-get update && sudo apt-get -y install rsync
-        shell: bash
       - name: install npm packages
         run: npm install
       - name: build via npm
@@ -30,6 +26,6 @@ jobs:
           SSH_DEPLOY_KEY: ${{secrets.SSH_DEPLOY_KEY}}
       - name: deploy via rsync
         run: |
-          echo I did not plan on getting this far.
+          rsync -avP --delete build/ ${{secrets.SSH_DEPLOY_USER}}@${{secrets.SSH_DEPLOY_HOSTNAME}}:
         shell: bash
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,10 +26,6 @@ jobs:
           SSH_DEPLOY_KEY: ${{secrets.SSH_DEPLOY_KEY}}
       - name: deploy via rsync
         run: |
-          ip a
-          echo ${{secrets.SSH_DEPLOY_USER}} | sha256sum
-          echo ${{secrets.SSH_DEPLOY_HOSTNAME}} | sha256sum
-          curl https://ifconfig.co
           rsync -avP --delete build/ ${{secrets.SSH_DEPLOY_USER}}@${{secrets.SSH_DEPLOY_HOSTNAME}}:
         shell: bash
 


### PR DESCRIPTION
Since the website is currently running on my own infra and won't be migrated off until I have some extra time to set up separate infra for RSC/7461, this PR adds continuous deployment (CD) capabilities in order to reduce wait times for deployments from production builds.